### PR TITLE
Update light capabilities

### DIFF
--- a/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
+++ b/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright (C) 2016-2017 The LineageOS Project
-
+     Copyright (C) 2015 The CyanogenMod Project
+                   2017-2018 The LineageOS Project
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-
           http://www.apache.org/licenses/LICENSE-2.0
-
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,20 +13,37 @@
      limitations under the License.
 -->
 <resources>
-   
     <!-- All the capabilities of the LEDs on this device, stored as a bit field.
          This integer should equal the sum of the corresponding value for each
          of the following capabilities present:
-
+         // Device has a color adjustable notification light.
          LIGHTS_RGB_NOTIFICATION_LED = 1
+         // Device has a color adjustable battery light.
          LIGHTS_RGB_BATTERY_LED = 2
-         LIGHTS_MULTIPLE_NOTIFICATION_LED = 4
+         LIGHTS_MULTIPLE_NOTIFICATION_LED = 4 (deprecated)
+         // The notification light has adjustable pulsing capability.
          LIGHTS_PULSATING_LED = 8
+         // Device has a multi-segment battery light that is able to
+         // use the light brightness value to determine how many
+         // segments to show (in order to represent battery level).
          LIGHTS_SEGMENTED_BATTERY_LED = 16
+         // The notification light supports HAL adjustable brightness
+         // via the alpha channel.
+         // Note: if a device notification light supports LIGHTS_RGB_NOTIFICATION_LED
+         // then HAL support is not necessary for brightness control.  In this case,
+         // brightness support will be provided by lineage-sdk through the scaling of
+         // RGB color values.
          LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS = 32
-
-         For example, a device support pulsating, RGB notification and
-         battery LEDs would set this config to 11. -->
-    <integer name="config_deviceLightCapabilities" translatable="false">43</integer>
-
+         // Device has a battery light.
+         LIGHTS_BATTERY_LED = 64
+         // The battery light supports HAL adjustable brightness via
+         // the alpha channel.
+         // Note: if a device battery light supports LIGHTS_RGB_BATTERY_LED then HAL
+         // support is not necessary for brightness control.  In this case,
+         // brightness support will be provided by lineage-sdk through the scaling of
+         // RGB color values.
+         LIGHTS_ADJUSTABLE_BATTERY_LED_BRIGHTNESS = 128
+         For example, a device with notification and battery lights that supports
+         pulsating and RGB control would set this config to 75. -->
+    <integer name="config_deviceLightCapabilities">75</integer>
 </resources>


### PR DESCRIPTION
1+2+8+64=75
"if a device battery light supports LIGHTS_RGB_NOTIFICATIO/BATTERY_LED then HAL support is not necessary for brightness control. In this case, brightness support will be provided by lineage-sdk through the scaling of RGB color values."